### PR TITLE
Added Spendabit URL

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -17,6 +17,7 @@ permalink: /community/merchants/index.html
         <ul class="logo">
           <li><a href="https://cryptwerk.com/pay-with/xmr/">cryptwerk.com</a></li>
           <li><a href="https://www.acceptedhere.io/catalog/currency/xmr/">acceptedhere.io</a></li>
+          <li><a href="https://spendabit.co/">spendabit.co</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
This PR adds a link to Spendabit, which allows for filtering on merchants that accept XMR... For example, if you search for "phones", you can then select to filter on merchants that take Monero.

For full disclosure, I work with the team at Spendabit. But we hope this will be a valuable resource to the Monero community.